### PR TITLE
MFA: further expanded descriptions and examples

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "develop"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To access a share, the receiving server MAY use multiple ways, depending on the 
 
 In both cases, when the share is a folder and the receiver accesses a resource within the share, it SHOULD append its relative path to that URL.
 
+Additionally, if `protocol.<protocolname>.permissions` include `mfa-enabled`, the receiver MUST be ready to receive a callback to the `/mfa-enabled` endpoint ([docs](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1mfa-enabled/get)), where it SHOULD confirm that the user accessing the resource has been authenticated with MFA. This implies that the provider MUST have stored the receiver's server address, e.g. via the [Invite](#invite) flow.
+
 ### Share Deletion
 A `"SHARE_ACCEPTED"` notification followed by a `"SHARE_UNSHARED"` notification is
 equivalent to a `"SHARE_DECLINED"` notification.
@@ -75,16 +77,9 @@ Following this step, both services at `sender.com` and `receiver.com` MAY displa
 For further details on this concept, see also [#54](https://github.com/cs3org/OCM-API/pull/54) and related issues. For a discussion about trust policies, see [sciencemesh#196](https://github.com/sciencemesh/sciencemesh/issues/196).
 
 ### Multi Factor Authentication
+If an OCM provider exposes the capability `/mfa-enabled`, it indicates that it will try and comply with a MFA requirement set as a permission on a share. If the sharer OCM provider trusts the receiver OCM provider, the sharer MAY set the permission `mfa-enforced` on a share, which MUST be enforced according to [the endpoint's description](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1mfa-enabled/get). A compliant OCM provider that signals that it is MFA-capable MUST not allow access to a resource to a user that has not provided a second factor to establish their identity with greater confidence.
 
-
-This specification contains a capability called `/mfa-capable` as well as a permission `mfa-enforced`.
-
-If an OCM provider has the capability `/mfa-capable` it will respond with a HTTP 200 OK on the endpoint `/mfa-capable` to indicate that it will try to comply with a MFA requirement set as a permission on a share. If the sharer OCM provider trusts the sharee OCM provider the sharer MAY set the permission mfa-enforced on a share.
-
-A complient OCM provider that signals that it is mfa-capable MUST not allow access to a resource to a user that has not provided a second factor to establish the identity of the user with greater confidence.
-
-Since there is no way to guarantee that the sharee OCM provider will actually enforce the MFA requirement, it is up to the sharer OCM provider to establish a trust with the OCM sharee provider such that it is reasonable to assume that the sharee OCM provider will honor the MFA requirement. This establishment of trust will inevitably be implementation dependent, and can be done for example using a pre approved allow list of trusted OCM providers. The procedure of establishing trust is out of scope for this specification.
-
+Since there is no way to guarantee that the sharee OCM provider will actually enforce the MFA requirement, it is up to the sharer OCM provider to establish a trust with the OCM sharee provider such that it is reasonable to assume that the sharee OCM provider will honor the MFA requirement. This establishment of trust will inevitably be implementation dependent, and can be done for example using a pre approved allow list of trusted OCM providers. The procedure of establishing trust is out of scope for this specification: a mechanism similar to the [ScienceMesh](https://sciencemesh.io) integration for the [Invite](#invite) capability may be envisaged.
 
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To access a share, the receiving server MAY use multiple ways, depending on the 
 
 In both cases, when the share is a folder and the receiver accesses a resource within the share, it SHOULD append its relative path to that URL.
 
-Additionally, if `protocol.<protocolname>.permissions` include `mfa-enabled`, the receiver MUST be ready to receive a callback to the `/mfa-enabled` endpoint ([docs](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1mfa-enabled/get)), where it SHOULD confirm that the user accessing the resource has been authenticated with MFA. This implies that the provider MUST have stored the receiver's server address, e.g. via the [Invite](#invite) flow.
+Additionally, if `protocol.<protocolname>.permissions` include `mfa-enforced`, the receiving host MUST ensure that the user accessing the resource has been authenticated with MFA.
 
 ### Share Deletion
 A `"SHARE_ACCEPTED"` notification followed by a `"SHARE_UNSHARED"` notification is
@@ -77,7 +77,7 @@ Following this step, both services at `sender.com` and `receiver.com` MAY displa
 For further details on this concept, see also [#54](https://github.com/cs3org/OCM-API/pull/54) and related issues. For a discussion about trust policies, see [sciencemesh#196](https://github.com/sciencemesh/sciencemesh/issues/196).
 
 ### Multi Factor Authentication
-If an OCM provider exposes the capability `/mfa-enabled`, it indicates that it will try and comply with a MFA requirement set as a permission on a share. If the sharer OCM provider trusts the receiver OCM provider, the sharer MAY set the permission `mfa-enforced` on a share, which MUST be enforced according to [the endpoint's description](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1mfa-enabled/get). A compliant OCM provider that signals that it is MFA-capable MUST not allow access to a resource to a user that has not provided a second factor to establish their identity with greater confidence.
+If an OCM provider exposes the capability `/mfa-capable`, it indicates that it will try and comply with a MFA requirement set as a permission on a share. If the sharer OCM provider trusts the receiver OCM provider, the sharer MAY set the permission `mfa-enforced` on a share, which SHOULD be honored. A compliant OCM provider that signals that it is MFA-capable MUST not allow access to a resource protected with the `mfa-enforced` permission, if the consumer has not provided a second factor to establish their identity with greater confidence.
 
 Since there is no way to guarantee that the sharee OCM provider will actually enforce the MFA requirement, it is up to the sharer OCM provider to establish a trust with the OCM sharee provider such that it is reasonable to assume that the sharee OCM provider will honor the MFA requirement. This establishment of trust will inevitably be implementation dependent, and can be done for example using a pre approved allow list of trusted OCM providers. The procedure of establishing trust is out of scope for this specification: a mechanism similar to the [ScienceMesh](https://sciencemesh.io) integration for the [Invite](#invite) capability may be envisaged.
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -108,21 +108,31 @@ paths:
               type: string
           schema:
             $ref: "#/definitions/Error"
-  /mfa-capable:
+  /mfa-enabled:
     get:
-      summary: Inform the sender that the provider will enforce MFA requirements.
+      summary: Request whether the consumer of a share has been authenticated with MFA.
       description: >
-        Signal that this OCM provider has the capability to enforce MFA requirements.
-        A sender MAY set the permission `mfa-enforced` on a share to this provider.
-        NOTE: There is no guarantee that the provider will actually enforce any MFA
+        When a consumer attempts to access a share that was created with the `mfa-enabled`
+        permission, the provider MUST request to the consumer's server whether the consumer
+        has been authenticated with MFA. The consumer server SHOULD enforce that a session
+        exists for the consumer and that it has been authenticated with MFA, or prompt
+        the consumer in order to elevate their session to MFA.
+        Note: There is no guarantee that the consumer service actually enforces any MFA
         requirements, so a trust must be established before relying on this capability.
+      parameters:
+        sharedSecret:
+          type: string
+          description: |
+            The secret identifying the share being accessed.
       responses:
         "200":
           description: |
-            The OCM service claims that it is capable of enforcing MFA requirements.
+            The user accessing the resource via the given `sharedSecret` has been
+            authenticated with MFA.
         "404":
           description: |
-            The OCM service does not have the capability to enforce MFA requirements.
+            There is no user accessing a share with the given `sharedSecret`, or
+            the endpoint does not have the capability to enforce MFA requirements.
   /notifications:
     post:
       summary: Send a notification to a remote party about a previously known entity
@@ -336,7 +346,7 @@ definitions:
           it is not necessary to expose it as a capability.
         items:
           type: string
-          enum: ["/notifications", "/invite-accepted", "/mfa-capable"]
+          enum: ["/notifications", "/invite-accepted", "/mfa-enabled"]
         example:
           ["/invite-accepted"]
   NewShare:
@@ -467,8 +477,9 @@ definitions:
                       - `read` allows read-only access including download of a copy.
                       - `write` allows create, update, and delete rights on the resource.
                       - `share` allows re-share rights on the resource.
-                      - `mfa-enforced`, this permission MAY be used if and only if the
-                        OCM provider has the capability `mfa-capable`.
+                      - `mfa-enforced` requires the user accessing the resource to be
+                        MFA-authenticated. This permission MAY be used if the
+                        provider exposes the `mfa-enabled` capability.
                     enum: ["read", "write", "share", "mfa-enforced"]
                 uri:
                   type: string
@@ -496,8 +507,9 @@ definitions:
                     - `view` allows access to the web app in view-only mode.
                     - `read` allows read and download access via the web app.
                     - `write` allows full editing rights via the web app.
-                    - `mfa-enforced`, this permission MAY be used if and only
-                      if the OCM provider has the capability `mfa-capable`.
+                    - `mfa-enforced` requires the user accessing the resource to be
+                      MFA-authenticated. This permission MAY be used if the
+                      provider exposes the `mfa-enabled` capability.
                   enum: ["view", "read", "write", "mfa-enforced"]
                 sharedSecret:
                   type: string
@@ -533,13 +545,13 @@ definitions:
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
             webdav:
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
-              permissions: ["read"]
+              permissions: ["read", "write"]
               uri: "https://open-cloud-mesh.org/remote.php/webdav/share-secret/path/to/resource.txt"
           multipleProtocols:
             name: "multi"
             options:
             webdav:
-              permissions: ["read"]
+              permissions: ["read", "mfa-enforced"]
               uri: "https://open-cloud-mesh.org/remote.php/webdav/share-secret/path/to/resource.txt"
             webapp:
               uriTemplate: "https://open-cloud-mesh.org/s/share-hash/{relative-path-to-shared-resource}"

--- a/spec.yaml
+++ b/spec.yaml
@@ -108,31 +108,26 @@ paths:
               type: string
           schema:
             $ref: "#/definitions/Error"
-  /mfa-enabled:
+  /mfa-capable:
     get:
-      summary: Request whether the consumer of a share has been authenticated with MFA.
+      summary: Inform the sender that the provider will enforce MFA requirements.
       description: >
-        When a consumer attempts to access a share that was created with the `mfa-enabled`
-        permission, the provider MUST request to the consumer's server whether the consumer
-        has been authenticated with MFA. The consumer server SHOULD enforce that a session
-        exists for the consumer and that it has been authenticated with MFA, or prompt
-        the consumer in order to elevate their session to MFA.
-        Note: There is no guarantee that the consumer service actually enforces any MFA
+        Signal that this OCM provider has the capability to enforce MFA when accessing
+        remote shares.
+        A sender MAY set the permission `mfa-enforced` on a share to this provider:
+        when a consumer attempts to access such a share, the consumer server SHOULD
+        enforce, prior to access, that a session exists for the consumer and that
+        it has been authenticated with MFA, or prompt the consumer in order to
+        elevate their session to MFA if that is applicable.
+        Note: there is no guarantee that the consumer service actually enforces any MFA
         requirements, so a trust must be established before relying on this capability.
-      parameters:
-        sharedSecret:
-          type: string
-          description: |
-            The secret identifying the share being accessed.
       responses:
         "200":
           description: |
-            The user accessing the resource via the given `sharedSecret` has been
-            authenticated with MFA.
+            The provider claims that it is capable of enforcing MFA requirements.
         "404":
           description: |
-            There is no user accessing a share with the given `sharedSecret`, or
-            the endpoint does not have the capability to enforce MFA requirements.
+            The provider does not have the capability to enforce MFA requirements.
   /notifications:
     post:
       summary: Send a notification to a remote party about a previously known entity
@@ -346,7 +341,7 @@ definitions:
           it is not necessary to expose it as a capability.
         items:
           type: string
-          enum: ["/notifications", "/invite-accepted", "/mfa-enabled"]
+          enum: ["/notifications", "/invite-accepted", "/mfa-capable"]
         example:
           ["/invite-accepted"]
   NewShare:
@@ -479,7 +474,7 @@ definitions:
                       - `share` allows re-share rights on the resource.
                       - `mfa-enforced` requires the user accessing the resource to be
                         MFA-authenticated. This permission MAY be used if the
-                        provider exposes the `mfa-enabled` capability.
+                        provider exposes the `mfa-capable` capability.
                     enum: ["read", "write", "share", "mfa-enforced"]
                 uri:
                   type: string
@@ -509,7 +504,7 @@ definitions:
                     - `write` allows full editing rights via the web app.
                     - `mfa-enforced` requires the user accessing the resource to be
                       MFA-authenticated. This permission MAY be used if the
-                      provider exposes the `mfa-enabled` capability.
+                      provider exposes the `mfa-capable` capability.
                   enum: ["view", "read", "write", "mfa-enforced"]
                 sharedSecret:
                   type: string


### PR DESCRIPTION
Hi there, we had a second look at this proposal and we may spell it out in more details, including resurrecting a `/mfa-enabled` endpoint that would have to be queried _at access time_ to validate that the recipient of a share does have a MFA token.

Please have a look/merge in your branch so that the top-level PR is updated. Thanks!